### PR TITLE
Add documentation, CLI prototype, and tests for Lazy God PoC

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.110.0
 uvicorn==0.23.0
-pydantic==1.10.9
+pydantic==2.6.4
+httpx==0.27.0
 dataclasses-json==0.6.3

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,15 +7,15 @@ and deterministic to enable reproducible runs in the CLI and API layers.
 The design is inspired by the technical specification provided in the PRD.
 """
 
-from .models import Nation, Assistant, Event, GameState, StabilityState
-from .game import GameEngine, Decision
+from .models import Decision, Nation, Assistant, Event, GameState, StabilityState
+from .game import GameEngine
 
 __all__ = [
+    "Decision",
     "Nation",
     "Assistant",
     "Event",
     "GameState",
     "StabilityState",
     "GameEngine",
-    "Decision",
 ]

--- a/core/models.py
+++ b/core/models.py
@@ -53,6 +53,12 @@ class StabilityState(str, enum.Enum):
     chaotic = "chaotic"
 
 
+class Decision(str, enum.Enum):
+    peace = "peace"
+    hostile = "hostile"
+    trade = "trade"
+
+
 HiddenTrait = str  # for simplicity; would be enum in full implementation
 RelationStatus = str  # neutral, allied, hostile, trading, etc.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+This folder provides JSON Schemas that mirror the simplified data models used by the prototype. They are intended for validation of save files, API responses, and long term contract tests.
+
+Schemas included:
+- nation_schema.json
+- assistant_schema.json
+- event_schema.json
+- gamestate_schema.json
+
+Validation tip:
+- Use ajv or python-jsonschema to validate example payloads from the running API.

--- a/docs/schemas/assistant_schema.json
+++ b/docs/schemas/assistant_schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "assistant.schema.json",
+  "type": "object",
+  "required": ["id", "name", "clazz", "rarity", "unlocked", "level", "effect", "cooldown"],
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "clazz": { "type": "string" },
+    "rarity": { "type": "string" },
+    "unlocked": { "type": "boolean" },
+    "level": { "type": "integer", "minimum": 1 },
+    "effect": {
+      "type": "object",
+      "required": ["type", "magnitude"],
+      "properties": {
+        "type": { "type": "string" },
+        "magnitude": { "type": "number", "minimum": 0, "maximum": 1 },
+        "charges": { "type": "integer", "minimum": 0 },
+        "duration_turns": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "cooldown": { "type": "integer", "minimum": 0 },
+    "cooldown_remaining": { "type": "integer", "minimum": 0 },
+    "flavor_text": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/event_schema.json
+++ b/docs/schemas/event_schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "event.schema.json",
+  "type": "object",
+  "required": ["id", "kind", "turn", "nations", "summary", "choices", "rng_seed"],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "type": "string" },
+    "turn": { "type": "integer", "minimum": 1 },
+    "nations": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "summary": { "type": "string" },
+    "choices": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key", "label", "effects"],
+        "properties": {
+          "key": { "type": "string" },
+          "label": { "type": "string" },
+          "effects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["target", "attribute", "delta"],
+              "properties": {
+                "target": { "type": "string" },
+                "attribute": { "type": "string" },
+                "delta": { "type": "number" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "constraints": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
+    "assistant_influence": { "type": "array", "items": { "type": "string" } },
+    "resolved": { "type": "boolean" },
+    "resolution": { "type": "object" },
+    "rng_seed": { "type": "integer" }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/gamestate_schema.json
+++ b/docs/schemas/gamestate_schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gamestate.schema.json",
+  "type": "object",
+  "required": ["run_id", "turn", "stability", "stability_state", "score", "peace_streak", "chaos_streak", "nations", "assistants", "events_log", "world_theme", "run_status", "turn_limit"],
+  "properties": {
+    "run_id": { "type": "string" },
+    "turn": { "type": "integer", "minimum": 1 },
+    "stability": { "type": "number", "minimum": 0, "maximum": 1 },
+    "stability_state": { "type": "string" },
+    "score": { "type": "integer", "minimum": 0 },
+    "peace_streak": { "type": "integer", "minimum": 0 },
+    "chaos_streak": { "type": "integer", "minimum": 0 },
+    "nations": { "type": "array" },
+    "assistants": { "type": "array" },
+    "events_log": { "type": "array" },
+    "world_theme": { "type": "string" },
+    "run_status": { "type": "string" },
+    "turn_limit": { "type": "integer" },
+    "autosave_slot": { "type": "string" },
+    "created_at": { "type": "string" },
+    "ended_at": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/nation_schema.json
+++ b/docs/schemas/nation_schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "nation.schema.json",
+  "type": "object",
+  "required": ["id", "name", "primary_race", "economy_type", "demeanor", "hidden_traits", "relations", "power", "population", "visibility"],
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string", "minLength": 3, "maxLength": 40 },
+    "primary_race": { "type": "string" },
+    "economy_type": { "type": "string" },
+    "demeanor": { "type": "string" },
+    "hidden_traits": { "type": "array", "items": { "type": "string" } },
+    "revealed_traits": { "type": "array", "items": { "type": "string" } },
+    "relations": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "power": { "type": "number", "minimum": 0, "maximum": 1 },
+    "population": { "type": "integer", "minimum": 10000 },
+    "prosperity": { "type": "number", "minimum": 0, "maximum": 1 },
+    "unrest": { "type": "number", "minimum": 0, "maximum": 1 },
+    "visibility": { "type": "string" },
+    "last_interaction": { "type": "string" },
+    "tags": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/prototype/cli_game.py
+++ b/prototype/cli_game.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.game import GameEngine
+from core.models import Decision
+
+PROMPT = "\nChoose [p]eace, [h]ostile, [t]rade or [q]uit: "
+
+def main(seed: int = 0) -> None:
+    engine = GameEngine(seed=seed)
+    state = engine.start_run()
+    run_id = state.run_id
+    print(f"Run started: {run_id}")
+    print("Tip: press q to quit at any time.")
+
+    while True:
+        event, error = engine.next_turn(run_id)
+        state = engine.get_state(run_id)
+        if error:
+            if error == "EVENT_PENDING" and state and state.events_log:
+                event = state.events_log[-1]
+            else:
+                print(f"\nError: {error}")
+                break
+
+        if event is None:
+            print("\nNo more events. Ending run.")
+            final = engine.end_run(run_id, reason="turn_limit")
+            print(f"Final score: {final['final_score']}")
+            break
+
+        assert state is not None
+        print(f"\nTurn {state.turn} | Stability: {state.stability:.2f} | Score: {state.score}")
+        print(f"Event: {event.summary}")
+        print(f"Involved nations: {', '.join(event.nations)}")
+        print("Choices:")
+        print("  p) Peace  h) Hostile  t) Trade  q) Quit")
+
+        choice = input(PROMPT).strip().lower()
+        if choice == "q":
+            final = engine.end_run(run_id, reason="player_quit")
+            print(f"\nYou quit. Final score: {final['final_score']}")
+            break
+        key_map = {"p": Decision.PEACE, "h": Decision.HOSTILE, "t": Decision.TRADE}
+        if choice not in key_map:
+            print("Invalid input. Try again.")
+            continue
+
+        updated_state, error = engine.make_decision(run_id, event.id, key_map[choice])
+        if error:
+            print(f"Error: {error}")
+            continue
+        assert updated_state is not None
+        resolution = updated_state.events_log[-1].resolution if updated_state.events_log else None
+        outcome_summary = resolution.logs[-1] if resolution else "Decision applied."
+        print(f"Outcome: {outcome_summary}")
+        print(
+            f"Stability: {updated_state.stability:.2f}  Score: {updated_state.score}  Peace streak: {updated_state.peace_streak}"
+        )
+
+        if updated_state.run_status in ("collapsed", "won", "turn_limit"):
+            final = engine.end_run(run_id, reason=updated_state.run_status)
+            print(f"\nRun ended. Reason: {updated_state.run_status}. Final score: {final['final_score']}")
+            break
+
+if __name__ == "__main__":
+    seed = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    main(seed)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+client = TestClient(app)
+
+
+def test_start_and_get_state_flow():
+    response = client.post("/runs/start", json={})
+    assert response.status_code == 200
+    payload = response.json()
+    run_id = payload["run_id"]
+
+    state_resp = client.get(f"/runs/{run_id}/state")
+    assert state_resp.status_code == 200
+    state = state_resp.json()["state"]
+    assert "stability" in state
+    assert "score" in state
+
+
+def test_next_and_decision_cycle():
+    response = client.post("/runs/start", json={})
+    run_id = response.json()["run_id"]
+
+    next_resp = client.post(f"/runs/{run_id}/next")
+    assert next_resp.status_code == 200
+    event = next_resp.json()["event"]
+
+    decision_body = {"event_id": event["id"], "choice": "peace"}
+    decision_resp = client.post(f"/runs/{run_id}/decision", json=decision_body)
+    assert decision_resp.status_code == 200
+    outcome = decision_resp.json()
+    assert "state" in outcome
+    assert "outcome_summary" in outcome

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.game import GameEngine
+from core.models import Decision, StabilityState
+
+
+def test_run_generates_event_and_updates_state():
+    engine = GameEngine(seed=123)
+    state = engine.start_run()
+    run_id = state.run_id
+
+    event, error = engine.next_turn(run_id)
+    assert error is None
+    assert event is not None
+
+    updated_state, error = engine.make_decision(run_id, event.id, Decision.peace)
+    assert error is None
+    assert updated_state is not None
+    assert 0.0 <= updated_state.stability <= 1.0
+    assert updated_state.score >= 0
+
+
+def test_stability_transitions_cover_thresholds():
+    engine = GameEngine(seed=42)
+    assert engine._compute_stability_state(0.95) == StabilityState.golden_age
+    assert engine._compute_stability_state(0.75) == StabilityState.peaceful
+    assert engine._compute_stability_state(0.5) == StabilityState.stable
+    assert engine._compute_stability_state(0.25) == StabilityState.tense
+    assert engine._compute_stability_state(0.05) == StabilityState.chaotic


### PR DESCRIPTION
## Summary
- add documentation README and JSON schemas covering nations, assistants, events, and game state contracts
- port the CLI prototype and centralize the Decision enum so the game engine, CLI, and API share logic, including an end_run helper
- update the FastAPI backend to a /runs namespace, refresh dependencies for Python 3.12, and add pytest smoke tests for core logic and API endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d01cfc344c832085a80c525d268f36