### PR TITLE
Revamp mobile UI for iPhone experience

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -16,6 +16,7 @@ body {
     radial-gradient(circle at 80% 0%, rgba(156, 108, 255, 0.2), transparent 52%),
     #050316;
   color: white;
+  overflow-x: hidden;
 }
 
 body::before {
@@ -46,6 +47,7 @@ body::before {
 .glass-panel {
   @apply bg-night-800/80 backdrop-blur-xl border border-white/10 shadow-card;
 }
+
 
 button:focus-visible {
   outline: 2px solid theme('colors.accent.secondary');

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -23,7 +23,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={clsx(outfit.variable, 'bg-night-900')}>
       <body className="min-h-screen bg-night-900 text-white antialiased">
-        <div className="relative mx-auto min-h-screen max-w-md px-4 pb-10 pt-6 sm:px-6">
+        <div
+          className="relative mx-auto flex min-h-screen w-full max-w-[420px] flex-col px-5 pb-[calc(5.5rem+env(safe-area-inset-bottom))] pt-6 sm:max-w-lg sm:px-6"
+        >
           <div className="pointer-events-none absolute inset-0 -z-10 bg-glow-grid opacity-80" />
           {children}
         </div>

--- a/frontend/components/DecisionButton.tsx
+++ b/frontend/components/DecisionButton.tsx
@@ -30,17 +30,17 @@ export default function DecisionButton({ choice, onSelect, disabled }: DecisionB
       disabled={disabled}
       onClick={() => onSelect(choice.key)}
       className={clsx(
-        'group relative flex items-center justify-between overflow-hidden rounded-2xl border border-white/10 px-5 py-4 text-left text-white shadow-lg transition',
+        'group relative flex w-full items-center justify-between overflow-hidden rounded-2xl border border-white/10 px-5 py-4 text-left text-white shadow-lg transition',
         disabled ? 'opacity-60' : 'hover:border-white/25 hover:shadow-xl',
       )}
     >
       <div className={clsx('absolute inset-0 bg-gradient-to-r opacity-90', gradientClass)} aria-hidden />
-      <div className="relative z-10 flex flex-col gap-2">
-        <span className="text-sm font-semibold uppercase tracking-[0.25em] text-white/80">
+      <div className="relative z-10 mr-4 flex min-w-0 flex-1 flex-col gap-2">
+        <span className="text-[0.7rem] font-semibold uppercase tracking-[0.25em] text-white/80">
           {formatDecisionLabel(choice.key)}
         </span>
-        <span className="text-base font-medium text-white/90">{choice.label}</span>
-        <div className="flex flex-wrap gap-2 text-xs text-white/80">
+        <span className="break-words text-base font-medium leading-snug text-white/90">{choice.label}</span>
+        <div className="flex flex-wrap gap-2 text-[0.7rem] text-white/80">
           {impact.stabilityDelta !== 0 && (
             <span className="rounded-full bg-white/15 px-3 py-1">
               Stability {impact.stabilityDelta > 0 ? '▲' : '▼'} {Math.abs(impact.stabilityDelta * 100).toFixed(0)}%
@@ -52,7 +52,7 @@ export default function DecisionButton({ choice, onSelect, disabled }: DecisionB
         </div>
       </div>
       <motion.span
-        className="relative z-10 text-2xl opacity-80"
+        className="relative z-10 shrink-0 text-2xl opacity-80"
         animate={{ rotate: disabled ? 0 : [0, 5, -5, 0] }}
         transition={{ duration: 2.5, repeat: disabled ? 0 : Infinity, ease: 'easeInOut' }}
       >

--- a/frontend/components/EventCard.tsx
+++ b/frontend/components/EventCard.tsx
@@ -13,18 +13,18 @@ interface EventCardProps {
 
 function NationPanel({ nation }: { nation: GameNation }) {
   return (
-    <div className="flex flex-col items-center rounded-2xl border border-white/5 bg-white/5 p-4 text-center">
+    <div className="flex w-full flex-col items-center rounded-2xl border border-white/5 bg-white/5 p-4 text-center">
       <div className="text-3xl drop-shadow">{getRaceEmoji(nation.primary_race)}</div>
-      <p className="mt-3 text-base font-semibold">{nation.name}</p>
-      <p className="text-xs uppercase tracking-[0.25em] text-white/40">{nation.primary_race}</p>
-      <div className="mt-3 grid w-full grid-cols-2 gap-2 text-[0.7rem] text-white/70">
+      <p className="mt-3 text-sm font-semibold leading-tight">{nation.name}</p>
+      <p className="text-[0.6rem] uppercase tracking-[0.25em] text-white/40">{nation.primary_race}</p>
+      <div className="mt-3 grid w-full grid-cols-2 gap-2 text-[0.65rem] text-white/70">
         <div className="rounded-lg bg-night-900/70 px-2 py-1">
-          <p className="font-semibold text-white/80">{formatPopulation(nation.population)}</p>
-          <p className="text-[0.6rem] uppercase tracking-[0.2em] text-white/40">Citizens</p>
+          <p className="text-sm font-semibold text-white/80">{formatPopulation(nation.population)}</p>
+          <p className="text-[0.55rem] uppercase tracking-[0.2em] text-white/40">Citizens</p>
         </div>
         <div className="rounded-lg bg-night-900/70 px-2 py-1">
-          <p className="font-semibold text-white/80">{Math.round(nation.prosperity * 100)}%</p>
-          <p className="text-[0.6rem] uppercase tracking-[0.2em] text-white/40">Prosperity</p>
+          <p className="text-sm font-semibold text-white/80">{Math.round(nation.prosperity * 100)}%</p>
+          <p className="text-[0.55rem] uppercase tracking-[0.2em] text-white/40">Prosperity</p>
         </div>
       </div>
     </div>
@@ -44,19 +44,19 @@ export default function EventCard({ event, nations, isProcessing }: EventCardPro
       transition={{ type: 'spring', stiffness: 120, damping: 20 }}
       className="glass-panel rounded-3xl p-5"
     >
-      <div className="flex items-center justify-between">
-        <p className="text-xs uppercase tracking-[0.3em] text-accent-secondary/90">Turn Event</p>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-[0.7rem] uppercase tracking-[0.25em] text-accent-secondary/90">Turn Event</p>
         <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[0.65rem] uppercase tracking-[0.25em] text-white/60">
           {event.kind}
         </span>
       </div>
-      <h2 className="mt-3 text-lg font-semibold text-white/90">{event.summary}</h2>
-      <div className="mt-4 grid grid-cols-2 gap-3">
+      <h2 className="mt-3 break-words text-lg font-semibold leading-snug text-white/90">{event.summary}</h2>
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
         {firstNation && <NationPanel nation={firstNation} />}
         {secondNation && <NationPanel nation={secondNation} />}
       </div>
-      <div className="mt-5 rounded-2xl border border-white/10 bg-night-900/80 px-4 py-3 text-xs text-white/70">
-        <p className="font-semibold uppercase tracking-[0.25em] text-white/40">Divine Insight</p>
+      <div className="mt-5 rounded-2xl border border-white/10 bg-night-900/80 px-4 py-3 text-[0.75rem] text-white/70">
+        <p className="text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-white/40">Divine Insight</p>
         <p className="mt-1 leading-relaxed">
           {isProcessing
             ? 'Intervention in progress… interpreting the ripples across the astral sea.'

--- a/frontend/components/GameScreen.tsx
+++ b/frontend/components/GameScreen.tsx
@@ -20,7 +20,7 @@ export default function GameScreen() {
   const runEnded = state.run_status !== 'active';
 
   return (
-    <div className="flex min-h-[calc(100vh-3rem)] flex-col gap-5 pb-16">
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col gap-6 pb-12">
       <HeaderCard state={state} outcomeSummary={outcomeSummary} mode={mode} />
 
       {error && (
@@ -75,7 +75,7 @@ export default function GameScreen() {
 
       <StatsPanel state={state} />
 
-      <footer className="mt-auto text-center text-[0.65rem] uppercase tracking-[0.3em] text-white/30">
+      <footer className="mt-auto px-2 text-center text-[0.6rem] uppercase tracking-[0.2em] text-white/30">
         Lazy God Prototype · Optimized for Vercel Edge
       </footer>
     </div>

--- a/frontend/components/HeaderCard.tsx
+++ b/frontend/components/HeaderCard.tsx
@@ -21,25 +21,29 @@ export default function HeaderCard({ state, outcomeSummary, mode }: HeaderCardPr
       transition={{ type: 'spring', stiffness: 120, damping: 18 }}
       className="glass-panel gradient-ring rounded-3xl p-5 text-white/90"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <p className="text-xs uppercase tracking-[0.3em] text-white/50">Turn {state.turn}</p>
-          <h1 className="mt-1 text-2xl font-semibold">Lazy God Console</h1>
-          <p className="text-xs text-white/60">World Theme · {state.world_theme.replace('_', ' ')}</p>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-[0.65rem] uppercase tracking-[0.25em] text-white/50">Turn {state.turn}</p>
+          <h1 className="mt-2 text-2xl font-semibold leading-tight">Lazy God Console</h1>
+          <p className="mt-1 text-[0.75rem] uppercase tracking-[0.25em] text-white/50">
+            World Theme · {state.world_theme.replace('_', ' ')}
+          </p>
         </div>
-        <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-right">
-          <p className="text-[0.65rem] uppercase tracking-[0.25em] text-white/50">Score</p>
-          <p className="text-lg font-semibold text-accent-amber">{state.score.toLocaleString()}</p>
-          <p className="text-[0.65rem] text-white/50">Peace Streak {state.peace_streak}</p>
+        <div className="flex w-full flex-wrap items-end justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm sm:w-auto sm:flex-col sm:items-end sm:text-right">
+          <div className="w-full text-left text-[0.6rem] uppercase tracking-[0.25em] text-white/50 sm:text-right">
+            Score
+          </div>
+          <p className="text-xl font-semibold text-accent-amber">{state.score.toLocaleString()}</p>
+          <p className="text-[0.7rem] text-white/60">Peace Streak {state.peace_streak}</p>
         </div>
       </div>
-      <div className="mt-5 space-y-3">
+      <div className="mt-5 space-y-4">
         <div>
-          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+          <div className="flex items-center justify-between text-[0.7rem] uppercase tracking-[0.25em] text-white/50">
             <span>World Stability</span>
-            <span>{stabilityLabel}</span>
+            <span className="font-medium text-white/70">{stabilityLabel}</span>
           </div>
-          <div className="mt-2 h-3 w-full overflow-hidden rounded-full bg-white/10">
+          <div className="mt-3 h-3 w-full overflow-hidden rounded-full bg-white/10">
             <motion.div
               className="h-full rounded-full bg-gradient-to-r from-accent-secondary to-accent-primary"
               initial={{ width: 0 }}
@@ -47,9 +51,9 @@ export default function HeaderCard({ state, outcomeSummary, mode }: HeaderCardPr
               transition={{ duration: 0.6, ease: 'easeOut' }}
             />
           </div>
-          <div className="mt-1 text-right text-xs font-semibold text-accent-secondary">{stabilityPercent}%</div>
+          <div className="mt-2 text-right text-xs font-semibold text-accent-secondary">{stabilityPercent}%</div>
         </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs text-white/70">
+        <div className="flex flex-wrap gap-2 text-[0.7rem] text-white/70">
           <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 font-medium">
             Mode · {mode === 'live' ? 'Connected' : 'Offline Simulation'}
           </span>
@@ -63,7 +67,7 @@ export default function HeaderCard({ state, outcomeSummary, mode }: HeaderCardPr
           )}
         </div>
         {outcomeSummary && (
-          <p className="rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-white/80">
+          <p className="rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm leading-relaxed text-white/80">
             {outcomeSummary}
           </p>
         )}

--- a/frontend/components/StatsPanel.tsx
+++ b/frontend/components/StatsPanel.tsx
@@ -11,13 +11,13 @@ interface StatsPanelProps {
 
 function AssistantBadge({ assistant }: { assistant: GameAssistant }) {
   return (
-    <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
-      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-night-900/70 text-xl">
+    <div className="flex min-w-0 items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-night-900/70 text-xl">
         🔮
       </div>
-      <div>
-        <p className="text-sm font-semibold text-white/90">{assistant.name}</p>
-        <p className="text-xs text-white/60">{assistant.flavor_text || `${assistant.clazz} · Lv ${assistant.level}`}</p>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-white/90">{assistant.name}</p>
+        <p className="truncate text-xs text-white/60">{assistant.flavor_text || `${assistant.clazz} · Lv ${assistant.level}`}</p>
       </div>
       <span className="ml-auto rounded-full bg-accent-primary/20 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-accent-primary">
         Ready
@@ -38,50 +38,52 @@ export default function StatsPanel({ state }: StatsPanelProps) {
       transition={{ type: 'spring', stiffness: 120, damping: 18 }}
       className="glass-panel rounded-3xl p-5"
     >
-      <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[0.7rem] uppercase tracking-[0.25em] text-white/50">
         <span>Strategic Overview</span>
-        <span>{getStabilityLabel(state.stability_state)}</span>
+        <span className="font-medium text-white/60">{getStabilityLabel(state.stability_state)}</span>
       </div>
       <div className="mt-4 grid gap-4">
-        <div className="grid grid-cols-2 gap-3 text-xs text-white/70">
+        <div className="grid grid-cols-1 gap-3 text-[0.75rem] text-white/70 sm:grid-cols-2">
           <div className="rounded-2xl bg-night-900/70 px-4 py-3">
-            <p className="text-[0.65rem] uppercase tracking-[0.25em] text-white/40">Peace Streak</p>
-            <p className="mt-1 text-xl font-semibold text-accent-secondary">{state.peace_streak}</p>
+            <p className="text-[0.6rem] uppercase tracking-[0.25em] text-white/40">Peace Streak</p>
+            <p className="mt-1 text-2xl font-semibold leading-tight text-accent-secondary">{state.peace_streak}</p>
           </div>
           <div className="rounded-2xl bg-night-900/70 px-4 py-3">
-            <p className="text-[0.65rem] uppercase tracking-[0.25em] text-white/40">Chaos Streak</p>
-            <p className="mt-1 text-xl font-semibold text-rose-300">{state.chaos_streak}</p>
+            <p className="text-[0.6rem] uppercase tracking-[0.25em] text-white/40">Chaos Streak</p>
+            <p className="mt-1 text-2xl font-semibold leading-tight text-rose-300">{state.chaos_streak}</p>
           </div>
         </div>
         <div>
-          <p className="text-[0.65rem] uppercase tracking-[0.25em] text-white/50">Trusted Assistants</p>
+          <p className="text-[0.6rem] uppercase tracking-[0.25em] text-white/50">Trusted Assistants</p>
           <div className="mt-2 space-y-2">
             {assistants.map((assistant) => (
               <AssistantBadge key={assistant.id} assistant={assistant} />
             ))}
             {assistants.length === 0 && (
-              <p className="rounded-2xl border border-dashed border-white/10 bg-night-900/50 px-4 py-6 text-center text-xs text-white/50">
+              <p className="rounded-2xl border border-dashed border-white/10 bg-night-900/50 px-4 py-6 text-center text-[0.7rem] text-white/50">
                 Assistants will join your cause as you progress.
               </p>
             )}
           </div>
         </div>
         <div>
-          <p className="text-[0.65rem] uppercase tracking-[0.25em] text-white/50">Prosperous Nations</p>
+          <p className="text-[0.6rem] uppercase tracking-[0.25em] text-white/50">Prosperous Nations</p>
           <div className="mt-3 flex flex-col gap-2">
             {trendingNations.map((nation) => (
               <div
                 key={nation.id}
-                className="flex items-center justify-between rounded-2xl border border-white/10 bg-night-900/60 px-4 py-3 text-sm text-white/80"
+                className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-night-900/60 px-4 py-3 text-sm text-white/80"
               >
-                <div className="flex items-center gap-3">
+                <div className="flex min-w-0 items-center gap-3">
                   <span className="text-xl">{getRaceEmoji(nation.primary_race)}</span>
-                  <div>
-                    <p className="font-semibold">{nation.name}</p>
-                    <p className="text-[0.65rem] uppercase tracking-[0.2em] text-white/40">{Math.round(nation.prosperity * 100)}% Prosperity</p>
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold">{nation.name}</p>
+                    <p className="text-[0.6rem] uppercase tracking-[0.2em] text-white/40">
+                      {Math.round(nation.prosperity * 100)}% Prosperity
+                    </p>
                   </div>
                 </div>
-                <span className="text-xs text-white/50">Power {Math.round(nation.power * 100)}</span>
+                <span className="shrink-0 text-[0.65rem] text-white/50">Power {Math.round(nation.power * 100)}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- refine the mobile container and background styling for safe-area padding and no horizontal scrolling
- restyle the header, event, and decision components for better readability and wrapping on small screens
- tighten the stats panel layout so data chips and assistant cards fit comfortably on modern phone widths

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d055107db08320ab2171a528a7442b