### PR TITLE
Add diplomat assistant unlock and update roadmap

### DIFF
--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -38,9 +38,9 @@ Deliver a self-contained build that one person can play end-to-end to evaluate t
 **Exit Criteria**: ✅ A single user can launch the web client locally, play a 5–10 minute session without crashes, and understand outcomes through UI feedback.
 
 ## Milestone 2 – Meta Progression Taste Test (1 sprint)
-1. **Assistant System**
-   - Implement Prophet (baseline) and Diplomat with simple unlock logic (e.g., reach streak of 5).
-   - Surface assistant hints and cooldowns in the UI.
+1. **Assistant System** – *in progress*
+   - ✅ Implement Prophet (baseline) alongside a Diplomat who unlocks after a peace streak of five and grants a stability bonus.
+   - ⏭️ Surface assistant hints and cooldowns in the UI.
 2. **Persistent Profile (Local)**
    - Store unlock flags and high scores in a JSON/SQLite file on the backend.
    - Display progression summary when starting a new run.


### PR DESCRIPTION
## Summary
- add a dedicated assistant roster so new runs include a locked Diplomat alongside the Prophet
- unlock the Diplomat after a peace streak of five, granting an additional stability bonus and logging the outcome
- update the development roadmap to record the completed assistant milestone and extend core tests to cover the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06fe22dc08320bcdd0f0a87009e1d